### PR TITLE
Modified FirebaseInstructorDataAccessObject with new method signatures

### DIFF
--- a/src/main/java/relay/data_access/FirebaseInstructorDataAccessObject.java
+++ b/src/main/java/relay/data_access/FirebaseInstructorDataAccessObject.java
@@ -19,7 +19,6 @@ public class FirebaseInstructorDataAccessObject {
      * Saves the provided Instructor object to the Firestore database.
      *
      * @param instructor The Instructor object to be saved.
-     * @return True if the save operation is successful, false otherwise.
      */
     public void save(Instructor instructor) {
         ApiFuture<DocumentReference> docRef = FirestoreSingleton.get().collection("instructors").add(instructor);
@@ -80,7 +79,7 @@ public class FirebaseInstructorDataAccessObject {
      * Deletes an Instructor object from the Firestore database based on the provided instructorID.
      *
      * @param instructorID The unique identifier of the Instructor to be deleted.
-     * @throws ResourceNotFoundException if
+     * @throws ResourceNotFoundException if the instructor does not exist in Firestore
      */
     public void delete(String instructorID) throws ResourceNotFoundException {
         if (!exists(instructorID)) {

--- a/src/main/java/relay/data_access/FirebaseInstructorDataAccessObject.java
+++ b/src/main/java/relay/data_access/FirebaseInstructorDataAccessObject.java
@@ -4,6 +4,7 @@ import com.google.api.core.ApiFuture;
 import com.google.cloud.firestore.DocumentReference;
 import com.google.cloud.firestore.DocumentSnapshot;
 import com.google.cloud.firestore.WriteResult;
+import relay.exceptions.ResourceNotFoundException;
 import relay.entity.Instructor;
 
 import java.util.concurrent.ExecutionException;
@@ -20,14 +21,12 @@ public class FirebaseInstructorDataAccessObject {
      * @param instructor The Instructor object to be saved.
      * @return True if the save operation is successful, false otherwise.
      */
-    public boolean save(Instructor instructor) {
+    public void save(Instructor instructor) {
         ApiFuture<DocumentReference> docRef = FirestoreSingleton.get().collection("instructors").add(instructor);
         try {
             instructor.setInstructorID(docRef.get().getId());
-            return true;
         } catch (InterruptedException | ExecutionException e) {
             e.printStackTrace();
-            return false;
         }
     }
 
@@ -81,20 +80,18 @@ public class FirebaseInstructorDataAccessObject {
      * Deletes an Instructor object from the Firestore database based on the provided instructorID.
      *
      * @param instructorID The unique identifier of the Instructor to be deleted.
-     * @return True if the delete operation is successful, false otherwise.
+     * @throws ResourceNotFoundException if
      */
-    public boolean delete(String instructorID) {
+    public void delete(String instructorID) throws ResourceNotFoundException {
         if (!exists(instructorID)) {
-            return false;
+            throw new ResourceNotFoundException();
         }
 
         ApiFuture<WriteResult> deleteResult = FirestoreSingleton.get().collection("instructors").document(instructorID).delete();
         try {
             deleteResult.get();
-            return true;
         } catch (InterruptedException | ExecutionException e) {
             e.printStackTrace();
-            return false;
         }
     }
 

--- a/src/main/java/relay/exceptions/ResourceNotFoundException.java
+++ b/src/main/java/relay/exceptions/ResourceNotFoundException.java
@@ -1,0 +1,4 @@
+package relay.exceptions;
+
+public class ResourceNotFoundException extends RuntimeException {
+}

--- a/src/test/java/relay/data_access/FirebaseInstructorDataAccessObjectTest.java
+++ b/src/test/java/relay/data_access/FirebaseInstructorDataAccessObjectTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import relay.entity.Instructor;
 import relay.entity.InstructorFactory;
+import relay.exceptions.ResourceNotFoundException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -40,7 +41,7 @@ public class FirebaseInstructorDataAccessObjectTest {
         Instructor testInstructor = InstructorFactory.createInstructor("first", "last", "first.last@gmail.com");
 
         // Save the Instructor
-        assertTrue(dataAccessObject.save(testInstructor));
+        dataAccessObject.save(testInstructor);
 
         // Read the saved Instructor
         Instructor retrievedInstructor = dataAccessObject.read(testInstructor.getInstructorID());
@@ -65,10 +66,10 @@ public class FirebaseInstructorDataAccessObjectTest {
         Instructor testInstructor = InstructorFactory.createInstructor("first", "last", "first.last@gmail.com");
 
         // Save the Instructor
-        assertTrue(dataAccessObject.save(testInstructor));
+        dataAccessObject.save(testInstructor);
 
         // Delete the saved Instructor
-        assertTrue(dataAccessObject.delete(testInstructor.getInstructorID()));
+        dataAccessObject.delete(testInstructor.getInstructorID());
 
         // Verify that the Instructor no longer exists in the database
         assertFalse(dataAccessObject.exists(testInstructor.getInstructorID()));
@@ -83,7 +84,7 @@ public class FirebaseInstructorDataAccessObjectTest {
         Instructor testInstructor = InstructorFactory.createInstructor("first", "last", "first.last@gmail.com");
 
         // Save the Instructor
-        assertTrue(dataAccessObject.save(testInstructor));
+        dataAccessObject.save(testInstructor);
 
         // Verify that the Instructor exists in the database
         assertTrue(dataAccessObject.exists(testInstructor.getInstructorID()));
@@ -97,9 +98,6 @@ public class FirebaseInstructorDataAccessObjectTest {
      */
     @Test
     void testReadNonExistentInstructor() {
-        // Make sure ID is non-existent
-        dataAccessObject.delete("nonexistentID");
-
         // Attempt to read an Instructor with a non-existent ID
         Instructor retrievedInstructor = dataAccessObject.read("nonexistentID");
 
@@ -112,8 +110,7 @@ public class FirebaseInstructorDataAccessObjectTest {
      */
     @Test
     void testDeleteNonExistentInstructor() {
-        dataAccessObject.delete("nonexistentID");
         // Attempt to delete an Instructor with a non-existent ID
-        assertFalse(dataAccessObject.delete("nonexistentID"));
+        assertThrows(ResourceNotFoundException.class, () -> dataAccessObject.delete("nonexistentID"));
     }
 }


### PR DESCRIPTION
## Summary
Changed method signatures of the `save`, and `delete` method in FirebaseInstructorDataAccessObject.

## Changes Made
- Removed boolean return from `save` method.
- Removed boolean return from `delete` method and instead raised `ResourceNotFoundException` when no instructor exists.
- Changed corresponding test files to reflect these changes.

## Testing
To validate the functionality of the FirebaseInstructorDataAccessObject, refer the to test file with the corresponding name that has been included in the test directory.