### PR TITLE
Modified FirebaseInstructorDataAccessObject with new method signatures and fixed issues

### DIFF
--- a/src/main/java/relay/data_access/FirebaseInstructorDataAccessObject.java
+++ b/src/main/java/relay/data_access/FirebaseInstructorDataAccessObject.java
@@ -3,6 +3,7 @@ package relay.data_access;
 import com.google.api.core.ApiFuture;
 import com.google.cloud.firestore.DocumentReference;
 import com.google.cloud.firestore.DocumentSnapshot;
+import com.google.cloud.firestore.Firestore;
 import com.google.cloud.firestore.WriteResult;
 import relay.exceptions.ResourceNotFoundException;
 import relay.entity.Instructor;
@@ -63,6 +64,9 @@ public class FirebaseInstructorDataAccessObject {
      * @return True if the Instructor exists, false otherwise.
      */
     public boolean exists(String instructorID) {
+        if (instructorID == null || instructorID.isEmpty()) {
+            return false;
+        }
         ApiFuture<DocumentSnapshot> future = FirestoreSingleton.get().collection("instructors").document(instructorID).get();
 
         try {

--- a/src/main/java/relay/data_access/FirebaseInstructorDataAccessObject.java
+++ b/src/main/java/relay/data_access/FirebaseInstructorDataAccessObject.java
@@ -19,7 +19,6 @@ public class FirebaseInstructorDataAccessObject {
      * Saves the provided Instructor object to the Firestore database.
      *
      * @param instructor The Instructor object to be saved.
-     * @return True if the save operation is successful, false otherwise.
      */
     public void save(Instructor instructor) {
         ApiFuture<DocumentReference> docRef = FirestoreSingleton.get().collection("instructors").add(instructor);
@@ -80,7 +79,7 @@ public class FirebaseInstructorDataAccessObject {
      * Deletes an Instructor object from the Firestore database based on the provided instructorID.
      *
      * @param instructorID The unique identifier of the Instructor to be deleted.
-     * @throws ResourceNotFoundException if
+     * @throws ResourceNotFoundException if the instructor does not exist in Firestore
      */
     public void delete(String instructorID) throws ResourceNotFoundException {
         if (!exists(instructorID)) {

--- a/src/main/java/relay/data_access/FirebaseInstructorDataAccessObject.java
+++ b/src/main/java/relay/data_access/FirebaseInstructorDataAccessObject.java
@@ -4,6 +4,7 @@ import com.google.api.core.ApiFuture;
 import com.google.cloud.firestore.DocumentReference;
 import com.google.cloud.firestore.DocumentSnapshot;
 import com.google.cloud.firestore.WriteResult;
+import relay.exceptions.ResourceNotFoundException;
 import relay.entity.Instructor;
 
 import java.util.concurrent.ExecutionException;
@@ -20,14 +21,12 @@ public class FirebaseInstructorDataAccessObject {
      * @param instructor The Instructor object to be saved.
      * @return True if the save operation is successful, false otherwise.
      */
-    public boolean save(Instructor instructor) {
+    public void save(Instructor instructor) {
         ApiFuture<DocumentReference> docRef = FirestoreSingleton.get().collection("instructors").add(instructor);
         try {
             instructor.setInstructorID(docRef.get().getId());
-            return true;
         } catch (InterruptedException | ExecutionException e) {
             e.printStackTrace();
-            return false;
         }
     }
 
@@ -81,20 +80,18 @@ public class FirebaseInstructorDataAccessObject {
      * Deletes an Instructor object from the Firestore database based on the provided instructorID.
      *
      * @param instructorID The unique identifier of the Instructor to be deleted.
-     * @return True if the delete operation is successful, false otherwise.
+     * @throws ResourceNotFoundException if
      */
-    public boolean delete(String instructorID) {
+    public void delete(String instructorID) throws ResourceNotFoundException {
         if (!exists(instructorID)) {
-            return false;
+            throw new ResourceNotFoundException();
         }
 
         ApiFuture<WriteResult> deleteResult = FirestoreSingleton.get().collection("instructors").document(instructorID).delete();
         try {
             deleteResult.get();
-            return true;
         } catch (InterruptedException | ExecutionException e) {
             e.printStackTrace();
-            return false;
         }
     }
 

--- a/src/main/java/relay/data_access/FirebaseInstructorDataAccessObject.java
+++ b/src/main/java/relay/data_access/FirebaseInstructorDataAccessObject.java
@@ -3,7 +3,6 @@ package relay.data_access;
 import com.google.api.core.ApiFuture;
 import com.google.cloud.firestore.DocumentReference;
 import com.google.cloud.firestore.DocumentSnapshot;
-import com.google.cloud.firestore.Firestore;
 import com.google.cloud.firestore.WriteResult;
 import relay.exceptions.ResourceNotFoundException;
 import relay.entity.Instructor;
@@ -22,12 +21,24 @@ public class FirebaseInstructorDataAccessObject {
      * @param instructor The Instructor object to be saved.
      */
     public void save(Instructor instructor) {
+        if (exists(instructor.getInstructorID())) {
+            update(instructor);
+        } else {
+            create(instructor);
+        }
+    }
+
+    private void create(Instructor instructor) {
         ApiFuture<DocumentReference> docRef = FirestoreSingleton.get().collection("instructors").add(instructor);
         try {
             instructor.setInstructorID(docRef.get().getId());
         } catch (InterruptedException | ExecutionException e) {
             e.printStackTrace();
         }
+    }
+
+    private void update(Instructor instructor) {
+        FirestoreSingleton.get().collection("instructors").document(instructor.getInstructorID()).set(instructor);
     }
 
     /**

--- a/src/main/java/relay/exceptions/ResourceNotFoundException.java
+++ b/src/main/java/relay/exceptions/ResourceNotFoundException.java
@@ -1,0 +1,4 @@
+package relay.exceptions;
+
+public class ResourceNotFoundException extends RuntimeException {
+}

--- a/src/test/java/relay/data_access/FirebaseInstructorDataAccessObjectTest.java
+++ b/src/test/java/relay/data_access/FirebaseInstructorDataAccessObjectTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import relay.entity.Instructor;
 import relay.entity.InstructorFactory;
+import relay.exceptions.ResourceNotFoundException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -40,7 +41,7 @@ public class FirebaseInstructorDataAccessObjectTest {
         Instructor testInstructor = InstructorFactory.createInstructor("first", "last", "first.last@gmail.com");
 
         // Save the Instructor
-        assertTrue(dataAccessObject.save(testInstructor));
+        dataAccessObject.save(testInstructor);
 
         // Read the saved Instructor
         Instructor retrievedInstructor = dataAccessObject.read(testInstructor.getInstructorID());
@@ -65,10 +66,10 @@ public class FirebaseInstructorDataAccessObjectTest {
         Instructor testInstructor = InstructorFactory.createInstructor("first", "last", "first.last@gmail.com");
 
         // Save the Instructor
-        assertTrue(dataAccessObject.save(testInstructor));
+        dataAccessObject.save(testInstructor);
 
         // Delete the saved Instructor
-        assertTrue(dataAccessObject.delete(testInstructor.getInstructorID()));
+        dataAccessObject.delete(testInstructor.getInstructorID());
 
         // Verify that the Instructor no longer exists in the database
         assertFalse(dataAccessObject.exists(testInstructor.getInstructorID()));
@@ -83,7 +84,7 @@ public class FirebaseInstructorDataAccessObjectTest {
         Instructor testInstructor = InstructorFactory.createInstructor("first", "last", "first.last@gmail.com");
 
         // Save the Instructor
-        assertTrue(dataAccessObject.save(testInstructor));
+        dataAccessObject.save(testInstructor);
 
         // Verify that the Instructor exists in the database
         assertTrue(dataAccessObject.exists(testInstructor.getInstructorID()));
@@ -97,9 +98,6 @@ public class FirebaseInstructorDataAccessObjectTest {
      */
     @Test
     void testReadNonExistentInstructor() {
-        // Make sure ID is non-existent
-        dataAccessObject.delete("nonexistentID");
-
         // Attempt to read an Instructor with a non-existent ID
         Instructor retrievedInstructor = dataAccessObject.read("nonexistentID");
 
@@ -112,8 +110,7 @@ public class FirebaseInstructorDataAccessObjectTest {
      */
     @Test
     void testDeleteNonExistentInstructor() {
-        dataAccessObject.delete("nonexistentID");
         // Attempt to delete an Instructor with a non-existent ID
-        assertFalse(dataAccessObject.delete("nonexistentID"));
+        assertThrows(ResourceNotFoundException.class, () -> dataAccessObject.delete("nonexistentID"));
     }
 }

--- a/src/test/java/relay/data_access/FirebaseInstructorDataAccessObjectTest.java
+++ b/src/test/java/relay/data_access/FirebaseInstructorDataAccessObjectTest.java
@@ -58,6 +58,25 @@ public class FirebaseInstructorDataAccessObjectTest {
     }
 
     /**
+     * Test that save called on an already saved instructor does not modify Instructor::instructorID.
+     */
+    @Test
+    void testSavingTwiceDoesNotModifyInstructorID() {
+        // Create a sample Instructor for testing
+        Instructor testInstructor = InstructorFactory.createInstructor("first", "last", "first.last@gmail.com");
+
+        dataAccessObject.save(testInstructor);
+        String previousID = testInstructor.getInstructorID();
+        dataAccessObject.save(testInstructor);
+        assert testInstructor.getInstructorID().equals(previousID);
+
+        // delete the saved instructor for cleanup
+        dataAccessObject.delete(testInstructor.getInstructorID());
+
+    }
+
+
+    /**
      * Test the deleting functionality of the {@link FirebaseInstructorDataAccessObject}.
      */
     @Test
@@ -76,10 +95,10 @@ public class FirebaseInstructorDataAccessObjectTest {
     }
 
     /**
-     * Test the existence checking functionality of the {@link FirebaseInstructorDataAccessObject}.
+     * Test whether exists method of {@link FirebaseInstructorDataAccessObject} correctly returns true.
      */
     @Test
-    void testExists() {
+    void testExistsReturnsTrue() {
         // Create a sample Instructor for testing
         Instructor testInstructor = InstructorFactory.createInstructor("first", "last", "first.last@gmail.com");
 
@@ -92,6 +111,34 @@ public class FirebaseInstructorDataAccessObjectTest {
         // Delete the instructor for cleanup
         dataAccessObject.delete(testInstructor.getInstructorID());
     }
+
+    /**
+     * Test whether exists method of {@link FirebaseInstructorDataAccessObject} correctly
+     * returns false with null instructorID.
+     */
+    @Test
+    void testExistsReturnsFalseWithNullInstructorID() {
+        assertFalse(dataAccessObject.exists(null));
+    }
+
+    /**
+     * Test whether exists method of {@link FirebaseInstructorDataAccessObject} correctly
+     * returns false with empty instructorID.
+     */
+    @Test
+    void testExistsReturnsFalseWithEmptyInstructorID() {
+        assertFalse(dataAccessObject.exists(""));
+    }
+
+    /**
+     * Test whether exists method of {@link FirebaseInstructorDataAccessObject} correctly
+     * returns false with blank instructorID.
+     */
+    @Test
+    void testExistsReturnsFalseWithBlankInstructorID() {
+        assertFalse(dataAccessObject.exists("      "));
+    }
+
 
     /**
      * Test reading a non-existent instructor from the {@link FirebaseInstructorDataAccessObject}.


### PR DESCRIPTION
## Summary
Changed method signatures of the `save`, and `delete` method in FirebaseInstructorDataAccessObject and fixed issues with `exists` method. 

## Changes Made
- Removed boolean return from `save` method.
- Removed boolean return from `delete` method and instead raised `ResourceNotFoundException` when no instructor exists.
- Fixed exists method to check for empty strings, which previously caused uncaught errors.
- Changed corresponding test files to reflect these changes.

## Testing
To validate the functionality of the FirebaseInstructorDataAccessObject, refer the to test file with the corresponding name that has been included in the test directory.
